### PR TITLE
Don't track notebook checkpoints in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+_notebooks/.ipynb_checkpoints


### PR DESCRIPTION
The only change here is in `.gitignore` to not stage .ipynb_checkpoints in git. 