### PR TITLE
Procfile.dev to use process manager locally

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+jekyll: bundle exec jekyll serve
+jupyter: jupyter notebook _notebooks


### PR DESCRIPTION
This adds a `Procfile.dev` that allows you to use [Foreman](https://github.com/ddollar/foreman) or [Hivemind](https://github.com/DarthSim/hivemind) to spin up both jekyll and jupyter notebooks in a single terminal tab:

<img width="1202" alt="Screen Shot 2020-01-28 at 10 53 25 AM" src="https://user-images.githubusercontent.com/43633/73295384-6e652180-41bc-11ea-9656-797ff052b364.png">