### PR TITLE
Conduct A Smoke Test of Jekyll Builds

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,0 +1,19 @@
+name: Smoke-Test
+on: [push]
+
+jobs:
+  jekyll-build-test-run:
+    runs-on: ubuntu-latest
+    container: jekyll/builder
+    steps:
+    - name: Copy Repository Contents
+      uses: actions/checkout@master
+
+    # We don't commit any files, just doing a dry run here
+    - name: Jekyll Build
+      run: |
+        chmod -R 777 .
+        bundle install
+        bundle exec jekyll build
+      env:
+        PAGES_REPO_NWO: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+_notebooks/.ipynb_checkpoints


### PR DESCRIPTION
This conducts a smoke test of the Jekyll Build process.  This is meant to help the contributors to this template see if PRs will break a Jekyll Page build before they are merged into master.   (And also give everyone more helpful errors than you get sometimes on the settings page)

A very basic test, but at least a starting point to hopefully catch problems.  

- I could add word and notebook conversion to the smoke test, but would need a place to store those test files so they can be downloaded into the Actions containers, but happy to add tests for that, too to this PR (or separate PRs) if you want.

- I could also add a badge to the README, but not sure if you want that or not.

- I have ideas for further automated tests that will allow you to see a preview of the website before merging, but that is more involved and we can discuss on a different thread if you are interested in that
